### PR TITLE
fix: persists base url after changing it

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -136,9 +136,6 @@ class Client implements HttpClientInterface
         }
 
         $this->httpManager = $httpManager ?? new GuzzleHttpManager($this, new Guzzle([
-            // Base URI is used with relative requests
-            'base_uri' => $this->baseUri(),
-            // You can set any number of default request options.
             'timeout'  => 10.0,
         ]));
     }

--- a/src/HttpClient/SendHttpRequests.php
+++ b/src/HttpClient/SendHttpRequests.php
@@ -81,7 +81,7 @@ trait SendHttpRequests
     public function request(string $method, string $route, array $data): ResponseInterface
     {
         try {
-            return $this->httpManager->request($method, $route, $data);
+            return $this->httpManager->request($method, $this->baseUri() . $route, $data);
         } catch (BadResponseException $th) {
             if ($th->hasResponse()) {
                 return $th->getResponse();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -52,9 +52,6 @@ class ClientTest extends TestCase
 
         $client->fillOptions([
             'httpManager' => new GuzzleHttpManager($client, new Guzzle([
-                // Base URI is used with relative requests
-                'base_uri' => $client->baseUri(),
-                // You can set any number of default request options.
                 'timeout'  => 10.0,
             ])),
         ]);
@@ -73,9 +70,6 @@ class ClientTest extends TestCase
 
         $client->fillOptions([
             'httpManager' => new GuzzleHttpManager($client, new Guzzle([
-                // Base URI is used with relative requests
-                'base_uri' => $client->baseUri(),
-                // You can set any number of default request options.
                 'timeout'  => 10.0,
             ])),
         ]);
@@ -94,9 +88,6 @@ class ClientTest extends TestCase
         $oldHttpManager = $client->getHttpManager();
 
         $client->setHttpManager($httpManager = new GuzzleHttpManager($client, new Guzzle([
-                // Base URI is used with relative requests
-                'base_uri' => $client->baseUri(),
-                // You can set any number of default request options.
                 'timeout'  => 10.0,
             ])));
 


### PR DESCRIPTION
No one have create issues for this yet but this is a bug... i found out that the base url on guzzle wont be updated after you change the url using the Client::fillOptions() method.

Since termii now have multiple base urls, this can be a very serious issue.